### PR TITLE
Set packs to auto during autostart.

### DIFF
--- a/Nasal/systems.nas
+++ b/Nasal/systems.nas
@@ -261,6 +261,8 @@ var startup = func {
 		    setprop("controls/APU/off-start-run", 0);
 		    setprop("controls/electric/APU-generator", 0);
 		    setprop("controls/pneumatic/apu-bleed", 0);
+		    setprop("controls/pneumatic/packs/pack-knob", 1);
+		    setprop("controls/pneumatic/packs/pack-knob[1]", 1);
 		}, 2);
 		removelistener(listener2);
 	    }


### PR DESCRIPTION
After using autostart the only message on EICAS remaining are of the packs.
This change sets them to auto after the enignes are running and providing
bleed air.
