### PR TITLE
Make EPR symmetric on both engines.

### DIFF
--- a/757-200-PW2040.xml
+++ b/757-200-PW2040.xml
@@ -93,7 +93,7 @@
 		<control-speed control="REVERSE_THRUST" transition-time="1.0" />
 		<actionpt x="-22.038" y="6.406" z="-0.801" />
 	</jet>
-	<jet x="-19.038" y="-6.406" z="-0.801" mass="7019.0" thrust="41700.0" afterburner="0.0" rotate="0.0" n1-idle="24.0" n1-max="102.0" n2-idle="70.0" n2-max="102.0" tsfc="0.322" egt="810.0" exhaust-speed="1555.0" spool-time="3.0">
+	<jet x="-19.038" y="-6.406" z="-0.801" mass="7019.0" thrust="41700.0" afterburner="0.0" rotate="0.0" n1-idle="24.0" n1-max="102.0" n2-idle="70.0" n2-max="102.0" tsfc="0.322" egt="810.0" exhaust-speed="1555.0" spool-time="3.0" epr-max="2.00">
 		<control-input axis="/controls/engines/engine[1]/throttle-lever" control="THROTTLE" />
 		<control-input axis="/controls/engines/engine[1]/reverser" control="REVERSE_THRUST" />
 		<control-output control="REVERSE_THRUST" prop="/surface-positions/right-reverser-pos-norm" />

--- a/757-200-RB211.xml
+++ b/757-200-RB211.xml
@@ -93,7 +93,7 @@
 		<control-speed control="REVERSE_THRUST" transition-time="1.0" />
 		<actionpt x="-22.038" y="6.406" z="-0.801" />
 	</jet>
-	<jet x="-19.038" y="-6.406" z="-0.801" mass="7294.0" thrust="40200.0" afterburner="0.0" rotate="0.0" n1-idle="24.0" n1-max="102.0" n2-idle="70.0" n2-max="102.0" tsfc="0.327" egt="810.0" exhaust-speed="1555.0" spool-time="3.0">
+	<jet x="-19.038" y="-6.406" z="-0.801" mass="7294.0" thrust="40200.0" afterburner="0.0" rotate="0.0" n1-idle="24.0" n1-max="102.0" n2-idle="70.0" n2-max="102.0" tsfc="0.327" egt="810.0" exhaust-speed="1555.0" spool-time="3.0" epr-max="2.00">
 		<control-input axis="/controls/engines/engine[1]/throttle-lever" control="THROTTLE" />
 		<control-input axis="/controls/engines/engine[1]/reverser" control="REVERSE_THRUST" />
 		<control-output control="REVERSE_THRUST" prop="/surface-positions/right-reverser-pos-norm" />


### PR DESCRIPTION
Only one of the engines (for both PW and RR) a non-default EPR is defined.
This would not help keeping it on the straight and narrow on takeoff.
