### PR TITLE
Improve cabin view position

### DIFF
--- a/757-200-main.xml
+++ b/757-200-main.xml
@@ -182,10 +182,10 @@
 			<config>
 				<from-model type="bool">true</from-model>
 				<x-offset-m archive="y">1</x-offset-m>
-				<y-offset-m archive="y">1.5</y-offset-m>
-				<z-offset-m archive="y">25</z-offset-m>
-				<heading-offset-deg>270</heading-offset-deg>
-				<pitch-offset-deg>0</pitch-offset-deg>
+				<y-offset-m archive="y">1.75</y-offset-m>
+				<z-offset-m archive="y">19.55</z-offset-m>
+				<heading-offset-deg>290</heading-offset-deg>
+				<pitch-offset-deg>-10</pitch-offset-deg>
 			</config>
 		</view>
 		<view n="101">


### PR DESCRIPTION
Cabin view position was no so interesting, low in between the seats.
This is elevated so the whole cabin can be seen, as well as moved
forward so that the wing leading edge and engine cowling can be seen
from the window.
