### PR TITLE
Make FLCH operate smoother and prevent A/T oscillations

### DIFF
--- a/Systems/757-autopilot.xml
+++ b/Systems/757-autopilot.xml
@@ -873,7 +873,7 @@
       <!--prop>/controls/flight/elevator-trim</prop-->
     </output>
     <config>
-      <Kp>-0.015</Kp>
+      <Kp>-0.010</Kp>
       <beta>1.0</beta>
       <alpha>0.1</alpha>
       <gamma>0.0</gamma>


### PR DESCRIPTION
The current FLCH operates somewhat rough, and combined with A/T can
cause oscillations. This PID parameter change smoothes out the
roughness, and allows for proper coordination with the A/T.
