### PR TITLE
Change initial value for FMS altitude to 10000ft

### DIFF
--- a/Nasal/AFDS.nas
+++ b/Nasal/AFDS.nas
@@ -70,7 +70,7 @@ var AFDS = {
         m.hdg_setting = m.AP_settings.initNode("heading-bug-deg",360,"INT");
         m.fpa_setting = m.AP_settings.initNode("flight-path-angle",0); # -9.9 to 9.9 #
         m.alt_setting = m.AP_settings.initNode("altitude-setting-ft",10000,"DOUBLE");
-        m.FMS_alt = m.AP_settings.initNode("target-altitude-ft",1,"DOUBLE");
+        m.FMS_alt = m.AP_settings.initNode("target-altitude-ft",10000,"DOUBLE");
         m.auto_brake_setting = m.AP_settings.initNode("autobrake",0.000,"DOUBLE");
 
         m.trk_setting = m.AFDS_settings.initNode("trk",0,"INT");


### PR DESCRIPTION
Change initial value for autopilot's FMS altitude to 10000ft like 747-8 does, so as to fix the problem of unexpected descending when activating autopilot after takeoff.